### PR TITLE
Allow to use ./gradlew build command and bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -22,12 +22,12 @@ allprojects {
 
 ext {
     compileSdkVersion = 25
-    buildToolsVersion = '25.0.2'
+    buildToolsVersion = '25.0.3'
     targetSdkVersion = compileSdkVersion
     minSdkVersion = 16
 
-    butterKnifeVersion = '8.5.1'
-    daggerVersion = '2.8'
+    butterKnifeVersion = '8.6.0'
+    daggerVersion = '2.11-rc2'
     espressoVersion = '2.2.2'
     junitVersion = '4.12'
     supportLibVersion = '25.3.1'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -21,6 +21,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 }
 
@@ -51,4 +55,5 @@ dependencies {
 
     // -- Picasso
     compile 'com.squareup.picasso:picasso:2.5.2'
+
 }

--- a/conductor_sample/build.gradle
+++ b/conductor_sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -24,6 +24,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage' // prevent error: https://github.com/square/okio/issues/58
     }
 }
 

--- a/fragment_sample/build.gradle
+++ b/fragment_sample/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -21,6 +22,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 
 }

--- a/fragment_sample_mvp/build.gradle
+++ b/fragment_sample_mvp/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -21,6 +22,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 
 }

--- a/mosby_fragment_sample/build.gradle
+++ b/mosby_fragment_sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -24,6 +24,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 }
 

--- a/mosby_sample/build.gradle
+++ b/mosby_sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -24,6 +24,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 }
 

--- a/simple_stack_sample/build.gradle
+++ b/simple_stack_sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
@@ -24,6 +24,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    lintOptions {
+        warning 'InvalidPackage'
     }
 }
 

--- a/simple_stack_sample/src/main/java/com/example/simplestacksample/MainActivity.java
+++ b/simple_stack_sample/src/main/java/com/example/simplestacksample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.example.simplestacksample;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -122,7 +123,7 @@ public class MainActivity
         //noinspection ResourceType
         return (MainActivity) context.getSystemService(TAG);
     }
-
+    @SuppressLint("WrongConstant")
     public static GitHubAPI getApi(Context context) {
         // noinspection ResourceType
         return (GitHubAPI) context.getSystemService("GITHUB_API");


### PR DESCRIPTION
- removed all critical lint warnings which did not allow to build the project
- add  @SuppressLint("WrongConstant")
- add vectorDrawables.useSupportLibrary = true to all projects' build.gradle
- add lintOptions { warning 'InvalidPackage' } to all projects' build.gradle

------

Bump Gradle dependencies:

- gradle build tools --> 2.3.2
- build tools --> 25.0.3
- butterknife --> 8.6.0
- dagger --> 2.11-rc2